### PR TITLE
fixed release artifacts archive types having duplicate dist folder inside

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -18,13 +18,13 @@ archives:
     id: "zip"
     wrap_in_directory: "true"
     files:
-      - dist/{{ .ProjectName }}_v{{ .Version }}
+      - none*
     name_template: 'extensions'
   - format: tar.gz
     id: "tar.gz"
     wrap_in_directory: 'extensions'
     files:
-      - dist/{{ .ProjectName }}_v{{ .Version }}
+      - none*
     name_template: 'extensions'
   - format: binary
     id: "binary"


### PR DESCRIPTION
## Summary
When release artifacts were created, goreleaser was putting the dist folder and the binary both inside the .tar.gz and .zip files. This would break lambda deployment. This PR fixes that. 

## Testing
Ran 
```
goreleaser release --snapshot --rm-dist
```
locally and checked the folder structure. 
