### PR TITLE
updating goreleaser go version

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -28,7 +28,7 @@ jobs:
         name: Set up Go
         uses: actions/setup-go@v2
         with:
-          go-version: 1.14
+          go-version: 1.16
       -
         name: Import GPG key
         id: import_gpg


### PR DESCRIPTION
## Summary
Goreleaser version was behind than the go mod file. This PR updates that.

## Next Steps
Rerun release tool.

