### PR TITLE
try to fix timeout caused by stop channel staying populated

### DIFF
--- a/pushers/pusher.go
+++ b/pushers/pusher.go
@@ -140,14 +140,10 @@ func (p *Pusher) run(id int, ctx context.Context) {
 			if ok && itemType == string(lambda.RuntimeDone) {
 				log.Printf("%s goroutine %d received runtime done", p.name, id)
 				p.runtimeDone <- struct{}{}
-				p.stopped <- struct{}{}
-				return
 			}
 		case <-ctx.Done():
 			log.Printf("%s goroutine %d context deadline reached", p.name, id)
 			p.runtimeDone <- struct{}{}
-			p.stopped <- struct{}{}
-			return
 		case <-p.stop:
 			log.Printf("%d goroutine stopped", id)
 			p.stopped <- struct{}{}


### PR DESCRIPTION
## Summary
Since I am not handling one message on the stop channel each time, it accumulates and causes goroutines to preemptively quit and miss runtime done events. This causes timeout errors where there's actually no timeout. 

## Testing
Will be testing with snowpipe router again. 

