### PR TITLE
add memory size to attributes

### DIFF
--- a/cfg/config.go
+++ b/cfg/config.go
@@ -40,6 +40,7 @@ type Config struct {
 	FunctionARN        string
 	ProcessRuntimeName string
 	HostArchitecture   string
+	MemorySize         string
 	BufferSize         int
 	FlushAtNextInvoke  bool
 }

--- a/main.go
+++ b/main.go
@@ -103,6 +103,7 @@ func startExtension() (*Worker, bool) {
 			}
 			config.HostArchitecture = strings.Join(architectures, ",")
 			config.ProcessRuntimeName = *function.Configuration.Runtime
+			config.MemorySize = fmt.Sprintf("%d", *function.Configuration.MemorySize)
 		}
 		log.Printf("Found lambda tags: %v", config.Tags)
 	}

--- a/pushers/processor.go
+++ b/pushers/processor.go
@@ -65,9 +65,9 @@ type edMetric struct {
 	RuntimeDurationMs     *float64 `json:"faas.runtime_duration_ms,omitempty"`
 	DurationMs            *float64 `json:"faas.duration_ms,omitempty"`
 	PostRuntimeDurationMs *float64 `json:"faas.post_runtime_duration_ms,omitempty"`
-	MaxMemoryUsed         *int     `json:"faas.max_memory_used,omitempty"`
-	MemoryLeft            *int     `json:"faas.memory_left,omitempty"`
-	MemoryPercent         *int     `json:"faas.memory_percent,omitempty"`
+	MaxMemoryUsed         *float64 `json:"faas.max_memory_used,omitempty"`
+	MemoryLeft            *float64 `json:"faas.memory_left,omitempty"`
+	MemoryPercent         *float64 `json:"faas.memory_percent,omitempty"`
 }
 
 type Processor struct {
@@ -279,10 +279,10 @@ func processPlatformReportEvent(e *lambda.LambdaEvent, cloudObj *cloud, hostArch
 		return nil, fmt.Errorf("failed to get request id in platform.report event: %v", e)
 	}
 
-	maxMemoryUsed, maxOk := metric["maxMemoryUsedMB"].(int)
-	memorySize, sizeOk := metric["memorySizeMB"].(int)
-	var memoryLeft *int
-	var memoryPercent *int
+	maxMemoryUsed, maxOk := metric["maxMemoryUsedMB"].(float64)
+	memorySize, sizeOk := metric["memorySizeMB"].(float64)
+	var memoryLeft *float64
+	var memoryPercent *float64
 	if maxOk && sizeOk {
 		mLeft := memorySize - maxMemoryUsed
 		mPercent := mLeft / memorySize * 100

--- a/pushers/processor.go
+++ b/pushers/processor.go
@@ -17,11 +17,12 @@ import (
 const sep = '\n'
 
 type faas struct {
-	Name      string            `json:"name"`
-	Version   string            `json:"version"`
-	RequestID string            `json:"request_id"`
-	Step      string            `json:"step,omitempty"`
-	Tags      map[string]string `json:"tags,omitempty"`
+	Name       string            `json:"name"`
+	Version    string            `json:"version"`
+	RequestID  string            `json:"request_id"`
+	MemorySize string            `json:"memory_size,omitempty"`
+	Step       string            `json:"step,omitempty"`
+	Tags       map[string]string `json:"tags,omitempty"`
 }
 
 type requestDuration struct {
@@ -64,10 +65,9 @@ type edMetric struct {
 	RuntimeDurationMs     *float64 `json:"faas.runtime_duration_ms,omitempty"`
 	DurationMs            *float64 `json:"faas.duration_ms,omitempty"`
 	PostRuntimeDurationMs *float64 `json:"faas.post_runtime_duration_ms,omitempty"`
-	MaxMemoryUsed         *float64 `json:"faas.max_memory_used,omitempty"`
-	MemorySize            *float64 `json:"faas.memory_size,omitempty"`
-	MemoryLeft            *float64 `json:"faas.memory_left,omitempty"`
-	MemoryPercent         *float64 `json:"faas.memory_percent,omitempty"`
+	MaxMemoryUsed         *int     `json:"faas.max_memory_used,omitempty"`
+	MemoryLeft            *int     `json:"faas.memory_left,omitempty"`
+	MemoryPercent         *int     `json:"faas.memory_percent,omitempty"`
 }
 
 type Processor struct {
@@ -75,6 +75,7 @@ type Processor struct {
 	cloud          *cloud
 	hostArch       string
 	processRuntime string
+	memorySize     string
 	outC           chan []byte
 	inC            chan []*lambda.LambdaEvent
 	invokeC        chan string
@@ -96,6 +97,7 @@ func NewProcessor(conf *cfg.Config, outC chan []byte, inC chan []*lambda.LambdaE
 		cloud:          &cloud{ResourceID: conf.FunctionARN, AccountID: conf.AccountID, Region: conf.Region},
 		hostArch:       conf.HostArchitecture,
 		processRuntime: conf.ProcessRuntimeName,
+		memorySize:     conf.MemorySize,
 	}
 }
 
@@ -121,6 +123,7 @@ func (p *Processor) Invoke(e *lambda.InvokeEvent) {
 
 func (p *Processor) run() {
 	faasObj.Tags = p.tags
+	faasObj.MemorySize = p.memorySize
 	faasObj.RequestID = ""
 	runtimeDone := false
 	for {
@@ -222,11 +225,12 @@ func processStartEvent(e *lambda.LambdaEvent, cloudObj *cloud, hostArch, process
 	edLog := &edLog{
 		common: common{
 			Faas: &faas{
-				Name:      faasObj.Name,
-				Version:   faasObj.Version,
-				Tags:      faasObj.Tags,
-				RequestID: requestID,
-				Step:      StartStep,
+				Name:       faasObj.Name,
+				Version:    faasObj.Version,
+				Tags:       faasObj.Tags,
+				MemorySize: faasObj.MemorySize,
+				RequestID:  requestID,
+				Step:       StartStep,
 			},
 			Cloud:              cloudObj,
 			LogType:            lambda.PlatformStart,
@@ -275,10 +279,10 @@ func processPlatformReportEvent(e *lambda.LambdaEvent, cloudObj *cloud, hostArch
 		return nil, fmt.Errorf("failed to get request id in platform.report event: %v", e)
 	}
 
-	maxMemoryUsed, maxOk := metric["maxMemoryUsedMB"].(float64)
-	memorySize, sizeOk := metric["memorySizeMB"].(float64)
-	var memoryLeft *float64
-	var memoryPercent *float64
+	maxMemoryUsed, maxOk := metric["maxMemoryUsedMB"].(int)
+	memorySize, sizeOk := metric["memorySizeMB"].(int)
+	var memoryLeft *int
+	var memoryPercent *int
 	if maxOk && sizeOk {
 		mLeft := memorySize - maxMemoryUsed
 		mPercent := mLeft / memorySize * 100
@@ -317,10 +321,11 @@ func processPlatformReportEvent(e *lambda.LambdaEvent, cloudObj *cloud, hostArch
 	edMetric := &edMetric{
 		common: common{
 			Faas: &faas{
-				Name:      faasObj.Name,
-				Version:   faasObj.Version,
-				Tags:      faasObj.Tags,
-				RequestID: requestID,
+				Name:       faasObj.Name,
+				Version:    faasObj.Version,
+				Tags:       faasObj.Tags,
+				MemorySize: faasObj.MemorySize,
+				RequestID:  requestID,
 			},
 			Cloud:              cloudObj,
 			LogType:            lambda.PlatformReport,
@@ -332,7 +337,6 @@ func processPlatformReportEvent(e *lambda.LambdaEvent, cloudObj *cloud, hostArch
 		BilledDurationMs:      utils.GetPointerIfNotDefaultValue(billedDuration),
 		InitDurationMs:        utils.GetPointerIfNotDefaultValue(initDurationMs),
 		MaxMemoryUsed:         utils.GetPointerIfNotDefaultValue(maxMemoryUsed),
-		MemorySize:            utils.GetPointerIfNotDefaultValue(memorySize),
 		RuntimeDurationMs:     runtimeDuration,
 		PostRuntimeDurationMs: postRuntimeDuration,
 		MemoryLeft:            memoryLeft,
@@ -363,11 +367,12 @@ func processRuntimeDoneEvent(e *lambda.LambdaEvent, cloudObj *cloud, hostArch, p
 	edLog := &edLog{
 		common: common{
 			Faas: &faas{
-				Name:      faasObj.Name,
-				Version:   faasObj.Version,
-				Tags:      faasObj.Tags,
-				RequestID: requestID,
-				Step:      EndStep,
+				Name:       faasObj.Name,
+				Version:    faasObj.Version,
+				Tags:       faasObj.Tags,
+				MemorySize: faasObj.MemorySize,
+				RequestID:  requestID,
+				Step:       EndStep,
 			},
 			Cloud:              cloudObj,
 			LogType:            lambda.PlatformRuntimeDone,


### PR DESCRIPTION
## Summary
Extension had only `memory_size` attribute on `platform.Report` event. This PR adds that attribute to each log. 

## Test
Published and tested with staging aws and prod poc org.
Example log with memory_size:
<img width="828" alt="image" src="https://github.com/edgedelta/edgedelta-lambda-extension/assets/111270176/0de9d8b2-1504-4ea8-9ecf-0ff81da74004">


