### PR TITLE
added tag prefixing

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ Supported ENV_VARIABLES for Lambda Function are:
 - ED_BUFFER_SIZE_MB: Maximum buffer size to keep logs (in MB). Default is 20. If stored logs exceed this limit, some logs may be dropped! 
 - ED_FLUSH_AT_NEXT_INVOKE: If set to 'true', logs are flushed at the start of next invocation of the function. Normally logs are flushed after function execution finishes which can add to total running time. For lambda functions that are executed periodically, flush at next invoke can be turned on to reduce cost.
 - ED_PRINT_EXTENSION_LOGS: If set to 'true', extension's own logs are printed in CloudWatch.
-- ED_TAG_PREFIX: The tag prefix to be added to the source tags. For example, if ED_TAG_PREFIX is "ed_prefix_", then all the tags will be prefixed with "ed_preix_". Default is empty.
+- ED_TAG_PREFIX: The tag prefix to be added to the source tags. For example, if ED_TAG_PREFIX is "ed_prefix_", then all the tags will be prefixed with "ed_prefix_". Default is empty.
   
 Lambda can buffer logs and deliver them to the subscriber. You can configure this behavior in the subscription request by specifying the following optional fields.
 - ED_LAMBDA_MAX_ITEMS: The maximum number of events to buffer in memory. Default: 1000. Minimum: 1000. Maximum: 10000. This is also the size of the channel that our http server writes into and pushers consume.

--- a/README.md
+++ b/README.md
@@ -43,6 +43,7 @@ Supported ENV_VARIABLES for Lambda Function are:
 - ED_BUFFER_SIZE_MB: Maximum buffer size to keep logs (in MB). Default is 20. If stored logs exceed this limit, some logs may be dropped! 
 - ED_FLUSH_AT_NEXT_INVOKE: If set to 'true', logs are flushed at the start of next invocation of the function. Normally logs are flushed after function execution finishes which can add to total running time. For lambda functions that are executed periodically, flush at next invoke can be turned on to reduce cost.
 - ED_PRINT_EXTENSION_LOGS: If set to 'true', extension's own logs are printed in CloudWatch.
+- ED_TAG_PREFIX: The tag prefix to be added to the source tags. For example, if ED_TAG_PREFIX is "ed_prefix_", then all the tags will be prefixed with "ed_preix_". Default is empty.
   
 Lambda can buffer logs and deliver them to the subscriber. You can configure this behavior in the subscription request by specifying the following optional fields.
 - ED_LAMBDA_MAX_ITEMS: The maximum number of events to buffer in memory. Default: 1000. Minimum: 1000. Maximum: 10000. This is also the size of the channel that our http server writes into and pushers consume.

--- a/cfg/config.go
+++ b/cfg/config.go
@@ -43,6 +43,7 @@ type Config struct {
 	MemorySize         string
 	BufferSize         int
 	FlushAtNextInvoke  bool
+	TagPrefix          string
 }
 
 func GetConfigAndValidate() (*Config, error) {
@@ -150,6 +151,12 @@ func GetConfigAndValidate() (*Config, error) {
 		config.LogTypes = usableLogTypes
 	} else {
 		config.LogTypes = []string{"platform", "function"}
+	}
+
+	tagPrefixStr := os.Getenv("ED_TAG_PREFIX")
+	config.TagPrefix = ""
+	if tagPrefixStr != "" {
+		config.TagPrefix = strings.TrimSpace(tagPrefixStr)
 	}
 
 	var err error

--- a/cfg/config.go
+++ b/cfg/config.go
@@ -154,7 +154,6 @@ func GetConfigAndValidate() (*Config, error) {
 	}
 
 	tagPrefixStr := os.Getenv("ED_TAG_PREFIX")
-	config.TagPrefix = ""
 	if tagPrefixStr != "" {
 		config.TagPrefix = strings.TrimSpace(tagPrefixStr)
 	}

--- a/main.go
+++ b/main.go
@@ -93,7 +93,10 @@ func startExtension() (*Worker, bool) {
 		}
 		config.Tags = make(map[string]string, len(function.Tags))
 		for k, v := range function.Tags {
-			config.Tags[k] = *v
+			var sb strings.Builder
+			sb.WriteString(config.TagPrefix)
+			sb.WriteString(k)
+			config.Tags[sb.String()] = *v
 		}
 
 		if function.Configuration != nil {


### PR DESCRIPTION
## Summary
- get tag prefix from env variables and then uses it to prefix the tags


## Testing
- pushed the layer as `arn:aws:lambda:us-west-2:757140585207:layer:edgedelta-lambda-extension:110`
- added this layer to the `flog-log-generator` [function](https://us-west-2.console.aws.amazon.com/lambda/home?region=us-west-2#/functions/flog-log-generator?tab=code)
- created a hosted agent and then set its http endpoint in `flog-log-generator` function
- set the `ED_TAG_PREFIX` environment variable to `ed_ahmet_prefix_text_`
- Then tested by running the function.
- Checked the logs uploaded to [s3](https://s3.console.aws.amazon.com/s3/buckets/ed-dev-customer-archive-logs?region=us-west-2&bucketType=general&prefix=0481a213-0186-460a-98f5-60a954bc0712/2024/01/18/13/86ecaeb6-7a64-4fb0-8f92-a82c9594077f/compactor/&showversions=false)
- other tags field from one of the log entries:
```
{...,
"other_tags":{
"faas.tags.ed_ahmet_prefix_text_flog_log_lambda_empty_tag":"",
...
"faas.tags.ed_ahmet_prefix_text_flog_log_lambda_test_1":"test_1",
...
"faas.tags.ed_ahmet_prefix_text_flog_log_lambda_application":"application"
},
...}
```
- the tags from aws lambda:

<img width="1372" alt="Screenshot 2024-01-18 at 15 07 30" src="https://github.com/edgedelta/edgedelta-lambda-extension/assets/108257949/dfb2990c-c26d-473e-af23-e2d85a30e406">

- From our log search:
<img width="1033" alt="Screenshot 2024-01-18 at 15 13 36" src="https://github.com/edgedelta/edgedelta-lambda-extension/assets/108257949/8eb811ce-dca6-4c47-9e83-2d4c8a304c1d">
- 
<img width="1370" alt="Screenshot 2024-01-18 at 15 16 24" src="https://github.com/edgedelta/edgedelta-lambda-extension/assets/108257949/9d61d64b-4631-4feb-b2d4-7c471b86f35e">








