### PR TITLE
build with CGO_ENABLED=0

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ Building and saving package into a bin/extensions directory:
 
 ```
 $ cd edgedelta-lambda-extension
-$ GOOS=linux GOARCH=amd64 go build -o bin/extensions/edgedelta-lambda-extension main.go
+$ CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build -o bin/extensions/edgedelta-lambda-extension main.go
 $ chmod +x bin/extensions/edgedelta-lambda-extension
 ```
 

--- a/deploy/build.sh
+++ b/deploy/build.sh
@@ -31,7 +31,7 @@ rm -rf "${project_root}/bin"
 mkdir -p "${project_root}/bin/extensions"
 
 cd "${project_root}"
-GOOS=linux GOARCH=$arch_type go build -o "$ext_path" main.go
+CGO_ENABLED=0 GOOS=linux GOARCH=$arch_type go build -o "$ext_path" main.go
 chmod +x "$ext_path"
 
 cd "${project_root}/bin"


### PR DESCRIPTION
## Summary
This PR passes `CGO_ENABLED=0` flag to build commend to ensure the built has no unnecessary C dependency. 

