### PR TITLE
[VPB-3484] - Timeout Events Handling

### DIFF
--- a/main.go
+++ b/main.go
@@ -167,6 +167,15 @@ func (w *Worker) Invoke(e *lambda.InvokeEvent) {
 	select {
 	case <-ctx.Done():
 		log.Print("Invocation context is done")
+		// short timeout context for sync flushing
+		flushCtx, flushCancel := context.WithTimeout(context.Background(), 200*time.Millisecond)
+		defer flushCancel()
+
+		if w.pusher.ForceFlush(flushCtx) {
+			log.Print("Successfully flushed logs on context done")
+		} else {
+			log.Print("Failed to flush logs on context done")
+		}
 		return
 	case <-doneC:
 		log.Print("Pusher is done")

--- a/main.go
+++ b/main.go
@@ -172,9 +172,9 @@ func (w *Worker) Invoke(e *lambda.InvokeEvent) {
 		defer flushCancel()
 
 		if w.pusher.ForceFlush(flushCtx) {
-			log.Print("Successfully flushed logs on context done")
+			log.Print("Successfully flushed logs on invocation context done")
 		} else {
-			log.Print("Failed to flush logs on context done")
+			log.Print("Failed to flush logs on invocation context done")
 		}
 		return
 	case <-doneC:

--- a/pushers/processor.go
+++ b/pushers/processor.go
@@ -51,6 +51,7 @@ type common struct {
 	LogType            lambda.EventType `json:"log_type"`
 	HostArchitecture   string           `json:"host.arch,omitempty"`
 	ProcessRuntimeName string           `json:"process.runtime.name,omitempty"`
+	Status             string           `json:"status,omitempty"`
 }
 
 type edLog struct {
@@ -364,6 +365,8 @@ func processRuntimeDoneEvent(e *lambda.LambdaEvent, cloudObj *cloud, hostArch, p
 		requestDurations[requestID].End = timestampEnd
 	}
 
+	status, _ := content["status"].(string)
+
 	edLog := &edLog{
 		common: common{
 			Faas: &faas{
@@ -379,6 +382,7 @@ func processRuntimeDoneEvent(e *lambda.LambdaEvent, cloudObj *cloud, hostArch, p
 			Timestamp:          e.EventTime,
 			HostArchitecture:   hostArch,
 			ProcessRuntimeName: processRuntime,
+			Status:             status,
 		},
 		Message: fmt.Sprintf("END RequestID: %s", faasObj.RequestID),
 	}

--- a/pushers/pusher.go
+++ b/pushers/pusher.go
@@ -231,7 +231,6 @@ func (p *Pusher) run() {
 				if err != nil {
 					log.Printf("Force flush failed: %v", err)
 				} else {
-					log.Print("Force flush completed successfully")
 					success = true
 				}
 				buf = new(bytes.Buffer)

--- a/pushers/pusher.go
+++ b/pushers/pusher.go
@@ -20,7 +20,6 @@ import (
 )
 
 const flushTimeout = 5 * time.Second
-const forceFlushTimeout = 150 * time.Millisecond
 
 var (
 	newHTTPClientFunc = func() *http.Client {
@@ -151,7 +150,7 @@ func (p *Pusher) run() {
 						// synchronous flushing with background context
 						log.Print("Runtime done with canceled context, performing immediate flush")
 						bgCtx := context.Background()
-						err := p.push(bgCtx, payload, forceFlushTimeout)
+						err := p.push(bgCtx, payload, 150*time.Millisecond)
 						if err != nil {
 							log.Printf("Immediate flush failed: %v", err)
 						} else {
@@ -173,7 +172,7 @@ func (p *Pusher) run() {
 				buf = new(bytes.Buffer)
 				// synchronous flushing with background context
 				bgCtx := context.Background()
-				err := p.push(bgCtx, payload, forceFlushTimeout)
+				err := p.push(bgCtx, payload, 150*time.Millisecond)
 				if err != nil {
 					log.Printf("Context done flush failed: %v", err)
 				} else {
@@ -228,7 +227,7 @@ func (p *Pusher) run() {
 			if buf.Len() > 0 {
 				payload := buf.Bytes()
 				// synchronous flushing with background context
-				err := p.push(context.Background(), payload, forceFlushTimeout)
+				err := p.push(context.Background(), payload, 150*time.Millisecond)
 				if err != nil {
 					log.Printf("Force flush failed: %v", err)
 				} else {

--- a/pushers/pusher.go
+++ b/pushers/pusher.go
@@ -20,6 +20,7 @@ import (
 )
 
 const flushTimeout = 5 * time.Second
+const forceFlushTimeout = 150 * time.Millisecond
 
 var (
 	newHTTPClientFunc = func() *http.Client {
@@ -150,7 +151,7 @@ func (p *Pusher) run() {
 						// synchronous flushing with background context
 						log.Print("Runtime done with canceled context, performing immediate flush")
 						bgCtx := context.Background()
-						err := p.push(bgCtx, payload, 150*time.Millisecond)
+						err := p.push(bgCtx, payload, forceFlushTimeout)
 						if err != nil {
 							log.Printf("Immediate flush failed: %v", err)
 						} else {
@@ -172,7 +173,7 @@ func (p *Pusher) run() {
 				buf = new(bytes.Buffer)
 				// synchronous flushing with background context
 				bgCtx := context.Background()
-				err := p.push(bgCtx, payload, 150*time.Millisecond)
+				err := p.push(bgCtx, payload, forceFlushTimeout)
 				if err != nil {
 					log.Printf("Context done flush failed: %v", err)
 				} else {
@@ -227,7 +228,7 @@ func (p *Pusher) run() {
 			if buf.Len() > 0 {
 				payload := buf.Bytes()
 				// synchronous flushing with background context
-				err := p.push(context.Background(), payload, 150*time.Millisecond)
+				err := p.push(context.Background(), payload, forceFlushTimeout)
 				if err != nil {
 					log.Printf("Force flush failed: %v", err)
 				} else {


### PR DESCRIPTION
## Summary
https://edgedelta.slack.com/archives/C02Q63ZADFZ/p1741212821509519

Fixes # 
[VPB-3484](https://edgedelta.atlassian.net/browse/VPB-3484)

## Testing

Used this pipeline, ingested both json parsed and raw bytes (4k log is due to that even I generated 2k log):
![image](https://github.com/user-attachments/assets/92c55e60-bc2a-4da4-9e88-115629e28255)


Tested with lambda function by commenting and uncommenting busy loop, I set lambda timeout to 5 second, I run both of the commented and uncommented tests twice
```javascript
export const handler = async (event) => {
 /* 
 while(true) {
   const startTime = Date.now();
   while(Date.now() - startTime < 100) {}
  }
*/
 
 for (let i = 1; i <= 1000; i++) {
    console.log(`Log entry ${i}: This is a test log message.`);
  }

  const response = {
    statusCode: 200,
    body: JSON.stringify('Hello from Lambda! 1000 logs have been generated.'),
  };

  return response;
  
};

```

As can be seen, 2 timeout and 2 success came under `@status` path `Lambda Status` facet and 4k logs are ingested as expected.
![image](https://github.com/user-attachments/assets/828d2231-53f1-4d50-8089-68440558c6aa)


### For repeated runs with `cold_start_test.sh` in this repo:

![image](https://github.com/user-attachments/assets/8cc5526e-d71e-4190-bfa7-03393c17f67d)


**Check first the timeout case:**
```bash
Cold Start Test 1: 8045 ms
Cold Start Test 2: 7593 ms
Cold Start Test 3: 7669 ms
Cold Start Test 4: 7868 ms
Cold Start Test 5: 7520 ms
Cold Start Test 6: 10282 ms
Cold Start Test 7: 7676 ms
Cold Start Test 8: 7635 ms
Cold Start Test 9: 7803 ms
Cold Start Test 10: 7794 ms
```

![image](https://github.com/user-attachments/assets/70b97c80-7020-425c-b65c-b30b2a9af2e5)

Per iteration:
There is 1 Start 1 End json format ingested
There is 1 Start 1 End raw format ingested

So we have 10 iteration; 10*4 = 40 logs
There is 1 platform metric (billed duration etc..) json format ingested, and raw format ingested total 2

40+2 = 42 logs ingested. 

There is 10 iteration we have `timeout` facet option count 10. 

![image](https://github.com/user-attachments/assets/e914cdd9-504f-4262-a09a-15671eea4068)


**Normal flow (without timeout/commented busy loop, 1000 logs printed per iteration and ingested both json and raw)**
```bash
Cold Start Test 1: 2069 ms
Cold Start Test 2: 2146 ms
Cold Start Test 3: 2064 ms
Cold Start Test 4: 1928 ms
Cold Start Test 5: 2280 ms
Cold Start Test 6: 2017 ms
Cold Start Test 7: 2001 ms
Cold Start Test 8: 1976 ms
Cold Start Test 9: 1957 ms
Cold Start Test 10: 2103 ms

```

![image](https://github.com/user-attachments/assets/0a7c4be1-f557-44b2-99a1-056cdd1a3dec)

There is 10 iteration we have `success` facet option count 10. 

![image](https://github.com/user-attachments/assets/d1e0ee89-3446-4db9-b9f6-158290422054)


### Inserted busy loop statement after printing 500 log to trigger timeout (500 logs printed and ingested both json and raw):

```javascript
export const handler = async (event) => {
  for (let i = 1; i <= 500; i++) {
    console.log(`Log entry ${i}: This is a test log message.`);
  }
  
  while(true) {
   const startTime = Date.now();
   while(Date.now() - startTime < 100) {}
  }
  
 
 for (let i = 1; i <= 500; i++) {
    console.log(`Log entry ${i}: This is a test log message.`);
  }

  const response = {
    statusCode: 200,
    body: JSON.stringify('Hello from Lambda! 1000 logs have been generated.'),
  };

  return response;
  
};

```

![image](https://github.com/user-attachments/assets/a80df4a1-ca80-46af-bfba-e9760a873399)

Since for this lambda run the status of the run is timeout, `Lambda Status` facet shows the status as `timeout`

## Next Steps
Release v0.0.9

